### PR TITLE
Fixed crash when trying to message disconnected workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ So long as the server you're trying to implement can read from a socket, this li
 
 ## Usage ##
 
-See /example/ for full code
+See /example/ for more detailed code and worker/master messaging.
 
 Main server.js file:
 

--- a/example/example.js
+++ b/example/example.js
@@ -24,7 +24,7 @@ if (cluster.isMaster) {
     });
 
     master.on("workerDied", function(event) {
-        console.log("Worker died:", event.worker, "with code", event.code);
+        console.log("Worker died:", event.worker.id, "with code", event.code);
         // Send a message to all workers
         master.broadcast("Worker " + event.worker.id + " died");
     });

--- a/lib/master.js
+++ b/lib/master.js
@@ -114,6 +114,8 @@ Master.prototype.balance = function(socket) {
 Master.prototype.broadcast = function(payload) {
     var message = { type: "sticky-server:broadcast", payload: payload };
     for (var i = 0; i < this.workers.length; i++) {
+        if (!this.workers[i].isConnected()) continue;
+
         this.workers[i].send(message);
     }
 };
@@ -123,6 +125,8 @@ Master.prototype.send = function(payload, workerId) {
     var message = { type: "sticky-server:broadcast", payload: payload, to: workerId };
     for (var i = 0; i < this.workers.length; i++) {
         if (this.workers[i].id === workerId) {
+            if (!this.workers[i].isConnected()) return;
+
             this.workers[i].send(message);
             return;
         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "name": "sticky-server",
   "version": "0.1.2",
-  "description": "Cluster server processes and route client sockets to the same worker every time",
+  "description": "Barebones server clustering which routes client sockets to the same worker every time",
+  "keywords": [
+      "server", "cluster", "consistent", "websocket", "networking"
+  ],
   "main": "lib/index.js",
   "scripts": {
     "test": "mocha ./test/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sticky-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Cluster server processes and route client sockets to the same worker every time",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Involved in this fix was an isConnected() call before attempting to send messages to workers.

Also added keywords to package.
