### PR TITLE
Added wait for crashed workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Also note that, since sticky-server doesn't host an http server of its own, you 
 
 ## Usage ##
 
-See /example/ for full code
+See the example for a full usage example.
 
 Main server.js file:
 
@@ -89,4 +89,4 @@ Since this package behaves differently depending on the number of cores availabl
 
     ...
 
-    13 passing (38ms)
+    15 passing (6s)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ sticky-server
 
 A small Node library designed to route incoming connections to individual worker processes. Heavily modeled after [sticky-session](https://github.com/indutny/sticky-session) and [node-cluster-socket.io](https://github.com/elad/node-cluster-socket.io), this package aims to provide socket/worker clustering in a server-independent manner.
 
-So long as the server you're trying to implement can read from a socket, this library should work.
+You must be able to pass a node socket to the server you're trying to use in a cluster.
+
+Since sticky-server doesn't host an http server of its own, you shouldn't have any issues with HTTP headers in reverse-proxy scenarios.
 
 ## Installation ##
 
@@ -15,7 +17,7 @@ See /example/ for full code
 
 Main server.js file:
 
-```node
+```javascript
 var cluster = require("cluster");
 var StickyServer = require("sticky-server");
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A small Node library designed to route incoming connections to individual worker
 
 You must be able to pass a node socket to the server you're trying to use in a cluster.
 
-Since sticky-server doesn't host an http server of its own, you shouldn't have any issues with HTTP headers in reverse-proxy scenarios.
+Also note that, since sticky-server doesn't host an http server of its own, you shouldn't have any issues with HTTP headers in reverse-proxy scenarios.
 
 ## Installation ##
 
@@ -13,7 +13,7 @@ Since sticky-server doesn't host an http server of its own, you shouldn't have a
 
 ## Usage ##
 
-See /example/ for more detailed code and worker/master messaging.
+See /example/ for full code
 
 Main server.js file:
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,10 +9,10 @@ var Worker  = require("./worker.js");
 // Options should be documented
 var defaultConfig = {
     respawnWorkers: "always", // never/error/always
-    maxWorkers: 0, // Max-available cores
-    maxBalanceAttempts: 3,
-    balanceWaitTime: 2000,
-    rerouteWorkers: false
+    rerouteWorkers: false, // Place connections with next available process on balance failure
+    maxWorkers: 0, // Max-available workers (0 = number of cores)
+    maxBalanceAttempts: 3, // Connection reroute attempts
+    balanceWaitTime: 3000 // Time to wait between reroute attempts
 };
 
 var StickyServer = function(config) {
@@ -20,7 +20,9 @@ var StickyServer = function(config) {
     // Parse provided config
     this.config = {
         respawnWorkers: (config.respawnWorkers || defaultConfig.respawnWorkers).toLowerCase(),
-        maxWorkers: config.maxWorkers || defaultConfig.maxWorkers
+        maxWorkers: config.maxWorkers || defaultConfig.maxWorkers,
+        maxBalanceAttempts: config.maxBalanceAttempts || defaultConfig.maxBalanceAttempts,
+        balanceWaitTime: config.balanceWaitTime || defaultConfig.balanceWaitTime
     };
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,10 @@ var Worker  = require("./worker.js");
 // Options should be documented
 var defaultConfig = {
     respawnWorkers: "always", // never/error/always
-    maxWorkers: 0 // Max-available cores
+    maxWorkers: 0, // Max-available cores
+    maxBalanceAttempts: 3,
+    balanceWaitTime: 2000,
+    rerouteWorkers: false
 };
 
 var StickyServer = function(config) {

--- a/lib/master.js
+++ b/lib/master.js
@@ -94,14 +94,55 @@ Master.prototype.getIndex = function(ip, len) {
 };
 
 // Distribute connections to workers
-Master.prototype.balance = function(socket) {
+Master.prototype.balance = function(socket, retries) {
+    // Make sure retries value is set
+    if (retries === undefined) {
+        retries = (this.config.maxBalanceAttempts || 3);
+    }
+
+    // Route socket to worker
+    var route = function route(worker, socket) {
+        // Send message to worker function containing socket
+        worker.send("sticky-server:connection", socket);
+
+        this.emit("connectionRouted", { worker: worker, socket: socket });
+    };
+
     var index = this.getIndex(socket.remoteAddress, this.workers.length);
     var worker = this.workers[index];
 
-    // Send message to worker function containing socket
-    worker.send("sticky-server:connection", socket);
+    // Check to see if worker is dead
+    if (!this.workers[i].isConnected()) {
+        // Check config, attempt to reroute
+        if (this.config.rerouteWorkers) {
+            for (var i = 0; i < this.workers.length; i++) {
+                // Skip dead workers
+                if (!this.workers[i].isConnected()) continue;
+                // Attempt to route to new connection
+                route(this.workers[i], socket);
+                return;
+            }
+            // No workers alive
+            throw new Error("Couldn't route connection; all workers are dead/disconnected");
+            socket.destroy();
+            return;
+        }else{
+            // Wait for worker to be available
+            if (retries <= 0) {
+                throw new Error("Worker didn't respawn in time for connection to be routed");
+                socket.destroy();
+                return;
+            }
+            // Wait for worker to return and make a new attempt
+            setTimeout(this.balance(socket, --retries), this.config.balanceWaitTime);
+        }
 
-    this.emit("connectionRouted", { worker: worker, socket: socket });
+        // Don't route normally
+        return;
+    }
+
+    // Default route
+    route(worker, socket)
 };
 
 module.exports = Master;

--- a/lib/master.js
+++ b/lib/master.js
@@ -112,13 +112,13 @@ Master.prototype.balance = function(socket, retries) {
         worker.send("sticky-server:connection", socket);
 
         this.emit("connectionRouted", { worker: worker, socket: socket });
-    };
+    }.bind(this);
 
     var index = this.getIndex(socket.remoteAddress, this.workers.length);
     var worker = this.workers[index];
 
     // Check to see if worker is dead
-    if (!this.workers[i].isConnected()) {
+    if (!worker.isConnected()) {
         // Check config, attempt to reroute
         if (this.config.rerouteWorkers) {
             for (var i = 0; i < this.workers.length; i++) {
@@ -129,14 +129,16 @@ Master.prototype.balance = function(socket, retries) {
                 return;
             }
             // No workers alive
-            throw new Error("Couldn't route connection; all workers are dead/disconnected");
+            //throw new Error("Couldn't route connection; all workers are dead/disconnected");
             socket.destroy();
+            this.emit("connectionDropped", { reason: "No available replacement worker", worker: worker, socket: socket });
             return;
         }else{
             // Wait for worker to be available
             if (retries <= 0) {
-                throw new Error("Worker didn't respawn in time for connection to be routed");
+                //throw new Error("Worker didn't respawn in time for connection to be routed");
                 socket.destroy();
+                this.emit("connectionDropped", { reason: "Worker didn't respawn in time to reconnect", worker: worker, socket: socket });
                 return;
             }
             // Wait for worker to return and make a new attempt

--- a/lib/master.js
+++ b/lib/master.js
@@ -142,7 +142,7 @@ Master.prototype.balance = function(socket, retries) {
                 return;
             }
             // Wait for worker to return and make a new attempt
-            setTimeout(this.balance(socket, --retries), this.config.balanceWaitTime);
+            setTimeout(function() { this.balance(socket, --retries) }.bind(this), this.config.balanceWaitTime);
         }
 
         // Don't route normally

--- a/lib/master.js
+++ b/lib/master.js
@@ -119,31 +119,15 @@ Master.prototype.balance = function(socket, retries) {
 
     // Check to see if worker is dead
     if (!worker.isConnected()) {
-        // Check config, attempt to reroute
-        if (this.config.rerouteWorkers) {
-            for (var i = 0; i < this.workers.length; i++) {
-                // Skip dead workers
-                if (!this.workers[i].isConnected()) continue;
-                // Attempt to route to new connection
-                route(this.workers[i], socket);
-                return;
-            }
-            // No workers alive
-            //throw new Error("Couldn't route connection; all workers are dead/disconnected");
+        // Wait for worker to be available
+        if (retries <= 0) {
+            //throw new Error("Worker didn't respawn in time for connection to be routed");
             socket.destroy();
-            this.emit("connectionDropped", { reason: "No available replacement worker", worker: worker, socket: socket });
+            this.emit("connectionDropped", { reason: "Worker didn't respawn in time to reconnect", worker: worker, socket: socket });
             return;
-        }else{
-            // Wait for worker to be available
-            if (retries <= 0) {
-                //throw new Error("Worker didn't respawn in time for connection to be routed");
-                socket.destroy();
-                this.emit("connectionDropped", { reason: "Worker didn't respawn in time to reconnect", worker: worker, socket: socket });
-                return;
-            }
-            // Wait for worker to return and make a new attempt
-            setTimeout(function() { this.balance(socket, --retries) }.bind(this), this.config.balanceWaitTime);
         }
+        // Wait for worker to return and make a new attempt
+        setTimeout(function() { this.balance(socket, --retries) }.bind(this), this.config.balanceWaitTime);
 
         // Don't route normally
         return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sticky-server",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Barebones server clustering which routes client sockets to the same worker every time",
   "keywords": [
       "server", "cluster", "consistent", "websocket", "networking"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sticky-server",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Barebones server clustering which routes client sockets to the same worker every time",
   "keywords": [
       "server", "cluster", "consistent", "websocket", "networking"

--- a/test/index.js
+++ b/test/index.js
@@ -319,51 +319,6 @@ describe("StickyServer Master", function() {
             done();
         });
     });
-    it("should attempt to rebalance connections to next available worker", function(done) {
-        this.timeout(2500);
-
-        var master = new StickyMaster(3033, {
-            maxWorkers: 0,
-            respawn: "never",
-            testing: {
-                fakeSpawn: true
-            },
-            balanceWaitTime: 2000,
-            maxBalanceAttempts: 2,
-            rerouteWorkers: true
-        });
-
-        var seedValue = master.indexSeed;
-
-        // Sample ip
-        var test = { in: "128.42.43.12", out: ((128424312 + seedValue) % numCPUs) };
-
-        // Spoof socket
-        var socket = new SocketMock(test.in);
-
-        // Kill designated worker before balance
-        master.workers[test.out].kill(0, "COODE");
-
-        master.balance(socket);
-
-        // Watch for failed route attempt
-        master.on("connectionDropped", function(details) {
-            throw new Error("Connection shouldn't be dropped in this test after worker is respawned");
-
-            done();
-        }.bind(this));
-
-        master.on("connectionRouted", function(details) {
-            if (test.out === 0) {
-                expect(details.worker).to.equal(master.workers[1]);
-            } else {
-                expect(details.worker).to.equal(master.workers[0]);
-            }
-            expect(details.socket).to.equal(socket);
-
-            done();
-        });
-    });
 });
 
 describe("StickyServer Worker", function() {

--- a/test/index.js
+++ b/test/index.js
@@ -209,8 +209,7 @@ describe("StickyServer Master", function() {
 
         for (var i = 0; i < tests.length; i++) {
             // Spoof socket
-            var socket = {};
-            socket.remoteAddress = tests[i].in;
+            var socket = new SocketMock(tests[i].in);
 
             master.balance(socket);
 

--- a/test/socketMock.js
+++ b/test/socketMock.js
@@ -1,0 +1,16 @@
+var events = require("events");
+
+var SocketMock = function SocketMock(addr) {
+    this.isDestroyed = false;
+    this.remoteAddress = (addr || "0.0.0.0");
+};
+
+// Inherit from EventEmitter
+SocketMock.prototype.__proto__ = events.EventEmitter.prototype;
+
+SocketMock.prototype.destroy = function() {
+    this.isDestroyed = true;
+    this.emit("destroy");
+};
+
+module.exports = SocketMock;

--- a/test/workerMock.js
+++ b/test/workerMock.js
@@ -18,4 +18,8 @@ WorkerMock.prototype.send = function(message, data) {
     this.emit("messageReceived", { message: message, socket: data });
 };
 
+WorkerMock.prototype.isConnected = function() {
+    return !this.killed;
+};
+
 module.exports = WorkerMock;


### PR DESCRIPTION
When a connection is routed to dead/disconnected workers, the framework will try 3 times to route the connection before failing.
